### PR TITLE
Fix og:description meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <title>Piscinas San José</title>
     <meta property="og:type" content="Web site">
     <meta property="og:title" content="PSJ | Empresa constructora de piscinas y piletas de natación">
-    <meta property="og:description" content="¡Recibí al mundial con tu pile! Empresa de construcción y mantenimiento de piscinas. Hacemos trabajos en todo el país. Cientos de clientes satisfechos y más de 40 años en el rubro.">+
+    <meta property="og:description" content="¡Recibí al mundial con tu pile! Empresa de construcción y mantenimiento de piscinas. Hacemos trabajos en todo el país. Cientos de clientes satisfechos y más de 40 años en el rubro.">
     <meta property="og:url" content="https://piscinassanjose.netlify.app/">
     <meta property="og:image" content="https://piscinassanjose.netlify.app/img/logo.png">
 </head>


### PR DESCRIPTION
## Summary
- remove stray plus sign after `og:description` meta tag in index.html

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a54e87d4a4832587e0a7d896a7670b