### PR TITLE
Add Jest DOM test for index.html

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "build-css": "node-sass --include-path scss scss/estilos.scss css/estilos.css",
     "watch-css": "nodemon -e scss -x \"npm run build-css\""
   },
@@ -19,6 +19,8 @@
   },
   "homepage": "https://github.com/LughDio/PROYECTO-LUCIANO-DIOTALLEVI#readme",
   "devDependencies": {
+    "jest": "^29.7.0",
+    "jsdom": "^24.0.0",
     "node-sass": "^7.0.3",
     "nodemon": "^2.0.20"
   }

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,0 +1,12 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+test('index.html contains h1 with Piscinas San José', () => {
+  const html = fs.readFileSync(path.resolve(__dirname, '../index.html'), 'utf8');
+  const dom = new JSDOM(html);
+  const h1 = dom.window.document.querySelector('h1');
+  expect(h1).not.toBeNull();
+  expect(h1.textContent.trim()).toBe('Piscinas San José');
+});
+


### PR DESCRIPTION
## Summary
- add Jest and jsdom as dev dependencies and update test script
- test index.html to ensure the H1 contains "Piscinas San José"

## Testing
- `npm install --save-dev jest jsdom` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a54e89e6fc8325860247dd80c44ca4