### PR TITLE
Add functional contact form

### DIFF
--- a/js/contact.js
+++ b/js/contact.js
@@ -1,0 +1,26 @@
+const form = document.getElementById('contact-form');
+const status = document.getElementById('form-status');
+
+if (form) {
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const formData = new FormData(form);
+    try {
+      const response = await fetch('https://formspree.io/f/mwkjedvd', {
+        method: 'POST',
+        headers: {
+          'Accept': 'application/json'
+        },
+        body: formData
+      });
+      if (response.ok) {
+        status.innerText = 'Gracias por tu consulta. Te responderemos pronto.';
+        form.reset();
+      } else {
+        status.innerText = 'Hubo un problema al enviar el formulario.';
+      }
+    } catch (error) {
+      status.innerText = 'Hubo un problema al enviar el formulario.';
+    }
+  });
+}

--- a/pages/contacto.html
+++ b/pages/contacto.html
@@ -38,12 +38,13 @@
     <main class="main hero">
         <section>
             <h2 class="animate__animated animate__fadeInUp">Contacto</h2>
-            <form action="">
-                <input type="text" name="Nombre" placeholder="Nombre">
-                <input type="text" name="Correo" placeholder="Correo">
-                <input type="text" name="Teléfono" placeholder="Teléfono">
+            <form id="contact-form" action="https://formspree.io/f/mwkjedvd" method="POST">
+                <input type="text" name="Nombre" placeholder="Nombre" required>
+                <input type="email" name="Correo" placeholder="Correo" required>
+                <input type="tel" name="Telefono" placeholder="Teléfono">
                 <textarea name="Consulta" placeholder="Dejanos tu consulta"></textarea>
-                <input type="button" value="ENVIAR" id="boton">
+                <input type="submit" value="ENVIAR" id="boton">
+                <p id="form-status"></p>
             </form>
         </section>
     </main>
@@ -54,5 +55,6 @@
     </footer>
 </body>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="../js/contact.js"></script>
 
 </html>


### PR DESCRIPTION
## Summary
- Add Formspree-based submission for the contact page
- Create JavaScript handler to send form data and show a success or error message

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e5f0b4c883259f5779b7d3770f8f